### PR TITLE
Develop

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    vimmer (0.1.0)
+    vimmer (0.2.0)
       thor
 
 GEM
@@ -71,6 +71,5 @@ DEPENDENCIES
   fuubar
   mocha
   rspec (~> 2.3.0)
-  thor
   vimmer!
   webmock

--- a/bin/vimmer
+++ b/bin/vimmer
@@ -1,3 +1,9 @@
 #!/usr/bin/env ruby
+
+libdir = "#{File.dirname(__FILE__)}/../lib"
+$:.unshift(File.expand_path(libdir)) unless
+    $:.include?(libdir) || $:.include?(File.expand_path(libdir))
+
+
 require 'vimmer/cli'
 Vimmer::CLI.start

--- a/features/install_git_plugin.feature
+++ b/features/install_git_plugin.feature
@@ -1,0 +1,28 @@
+Feature: Install git:// plugin
+
+  Background:
+    Given a directory named ".vimmer"
+    And a bundle path set for my system
+    And I have no plugins installed
+    
+  Scenario: Install from wincent.com
+    When I successfully run "vimmer install git://git.wincent.com/command-t.git"
+    Then a git plugin named "command-t" should be installed
+    And the stdout should contain "command-t has been installed"
+
+  Scenario: Install from a git url with bad URL
+    When I run "vimmer install 'git://git.wincent.com/not-found.git'"
+    Then I should still not have any plugins installed
+    And it should fail with:
+    """
+    The plugin not-found could not be found
+    """
+
+  Scenario: Install from git url with a git protocol URL
+    When I run "vimmer install 'http://git.wincent.com/command-t.git'"
+    Then I should still not have any plugins installed
+    And it should fail with:
+    """
+    The URL http://git.wincent.com/command-t.git is invalid.
+    """
+

--- a/features/install_github_plugin.feature
+++ b/features/install_github_plugin.feature
@@ -1,4 +1,4 @@
-Feature: Install plugin
+Feature: Install github plugin
 
   Background:
     Given a directory named ".vimmer"
@@ -7,7 +7,7 @@ Feature: Install plugin
 
   Scenario: Install from Github
     When I successfully run "vimmer install 'https://github.com/tpope/vim-awesomemofo.git'"
-    Then a plugin named "vim-awesomemofo" should be installed
+    Then a github plugin named "vim-awesomemofo" should be installed
     And the stdout should contain "vim-awesomemofo has been installed"
 
   Scenario: Install from Github with bad URL
@@ -28,7 +28,7 @@ Feature: Install plugin
 
   Scenario Outline: Install from Github with a front-end Github URL
     When I successfully run "vimmer install '<URL>'"
-    Then a plugin named "vim-awesomemofo" should be installed
+    Then a github plugin named "vim-awesomemofo" should be installed
     And the stdout should contain "vim-awesomemofo has been installed"
 
     Examples:
@@ -43,8 +43,4 @@ Feature: Install plugin
     awesomemofo.vim has been installed
     """
 
-  @wip
-  Scenario: Install from vim.org
-    When I successfully run "vimmer install http://www.vim.org/scripts/script.php?script_id=2975"
-    Then a plugin named "fugitive.vim" should be installed
-    And the stdout should contain "fugitive.vim has been installed"
+

--- a/features/install_vim_dot_org_plugin.feature
+++ b/features/install_vim_dot_org_plugin.feature
@@ -1,0 +1,14 @@
+Feature: Install vim.org plugin
+
+  Background:
+    Given a directory named ".vimmer"
+    And a bundle path set for my system
+    And I have no plugins installed
+
+  @wip
+  Scenario: Install from vim.org
+    When I successfully run "vimmer install http://www.vim.org/scripts/script.php?script_id=2975"
+    Then a github plugin named "fugitive.vim" should be installed
+    And the stdout should contain "fugitive.vim has been installed"
+
+

--- a/features/step_definitions/plugin_assertion_steps.rb
+++ b/features/step_definitions/plugin_assertion_steps.rb
@@ -1,6 +1,11 @@
-Then /^a plugin named "([^"]*)" should be installed$/ do |name|
+Then /^a github plugin named "([^"]*)" should be installed$/ do |name|
   @vimmer.installed_plugins.should include(name)
   @vimmer.plugin_store[name].should =~ %r{https://github.com/.*/#{name}\.git}
+end
+
+Then /^a git plugin named "([^"]*)" should be installed$/ do |name|
+  @vimmer.installed_plugins.should include(name)
+  @vimmer.plugin_store[name].should =~ %r{git://(\w|[.+/])+/#{name}\.git}
 end
 
 Then /^I should still not have any plugins installed$/ do

--- a/features/support/setup.rb
+++ b/features/support/setup.rb
@@ -1,5 +1,6 @@
 require 'aruba/cucumber'
 require 'webmock'
+require 'pathname'
 require File.dirname(__FILE__) + '/stubbed_http_requests'
 
 ENV['RUBYOPT'] = "-r#{File.expand_path(File.join(File.dirname(__FILE__), 'stub-commands.rb'))} -rwebmock -r#{File.expand_path(File.join(File.dirname(__FILE__), 'stubbed_http_requests'))} #{ENV['RUBYOPT']}"

--- a/features/uninstall_plugin.feature
+++ b/features/uninstall_plugin.feature
@@ -10,6 +10,11 @@ Feature: Uninstall plugin
     And I successfully run "vimmer uninstall 'vim-awesomemofo'"
     Then I should still not have any plugins installed
 
+  Scenario: Uninstall from a git:// url
+    When I successfully run "vimmer install 'git://git.wincent.com/command-t.git'"
+    And I successfully run "vimmer uninstall 'command-t'"
+    Then I should still not have any plugins installed
+
   Scenario: Attempt to uninstall a plugin that is not installed
     When I run "vimmer uninstall not_installed"
     Then it should fail with:

--- a/lib/vimmer/cli.rb
+++ b/lib/vimmer/cli.rb
@@ -10,7 +10,8 @@ module Vimmer
       begin
         installer = Vimmer::Installers.for_url(path)
         # TODO: Make this consistent with VimDotOrg installer
-        if installer == Vimmer::Installers::Github
+        if installer == Vimmer::Installers::Github ||
+           installer == Vimmer::Installers::GitUrl
           installer = installer.new(:path => path)
         end
         installer.install

--- a/lib/vimmer/installers.rb
+++ b/lib/vimmer/installers.rb
@@ -3,12 +3,15 @@ module Vimmer
     extend self
 
     autoload :Github,      'vimmer/installers/github'
+    autoload :GitUrl,      'vimmer/installers/git_url'
     autoload :VimDotOrg,   'vimmer/installers/vim_dot_org'
 
 
     def for_url(url)
       if Github.match?(url)
         Github
+      elsif GitUrl.match?(url)
+        GitUrl
       elsif VimDotOrg.match?(url)
         VimDotOrg.for_url(url)
       else

--- a/lib/vimmer/installers.rb
+++ b/lib/vimmer/installers.rb
@@ -2,10 +2,10 @@ module Vimmer
   module Installers
     extend self
 
-    autoload :Github,      'vimmer/installers/github'
-    autoload :GitUrl,      'vimmer/installers/git_url'
-    autoload :VimDotOrg,   'vimmer/installers/vim_dot_org'
-
+    autoload :BaseInstaller, 'vimmer/installers/base_installer'
+    autoload :Github,        'vimmer/installers/github'
+    autoload :GitUrl,        'vimmer/installers/git_url'
+    autoload :VimDotOrg,     'vimmer/installers/vim_dot_org'
 
     def for_url(url)
       if Github.match?(url)

--- a/lib/vimmer/installers/base_installer.rb
+++ b/lib/vimmer/installers/base_installer.rb
@@ -33,7 +33,7 @@ module Vimmer
       end
 
       def path_exists?
-        `curl --head -w %{http_code} -o /dev/null #{remove_extension(path)} 2> /dev/null`.chomp == "200"
+        `curl --head -w %{http_code} -o /dev/null #{curl_url(path)} 2> /dev/null`.chomp == "200"
       end
 
       private
@@ -42,9 +42,18 @@ module Vimmer
         output = `git clone #{path} #{install_to}`
       end
 
+      def curl_url(path)
+        curl_path = remove_extension(path)
+        curl_path = make_protocol_http(curl_path)
+      end
+
       def remove_extension(path)
         path.gsub(/\.git$/, '')
-      end      
+      end     
+
+      def make_protocol_http(path)
+        path.gsub(%r{git://},'http://')
+      end
 
      def initialize_with_name(name)
         @path = Vimmer.plugins[name]

--- a/lib/vimmer/installers/base_installer.rb
+++ b/lib/vimmer/installers/base_installer.rb
@@ -1,0 +1,55 @@
+module Vimmer
+  module Installers
+    class BaseInstaller
+      attr_reader :path, :plugin_name
+
+      def initialize(args={})
+        if args[:path]
+          initialize_with_path(args[:path])
+        elsif args[:name]
+          initialize_with_name(args[:name])
+        end
+      end 
+
+      def install
+        if path_exists?
+          git_clone(path, File.join(Vimmer.bundle_path, plugin_name))
+          Vimmer.add_plugin(plugin_name, path)
+          puts "#{plugin_name} has been installed"
+        else
+          raise Vimmer::PluginNotFoundError
+        end
+      end
+
+      def uninstall
+        plugin_path = File.join(Vimmer.bundle_path, plugin_name)
+        if File.directory? plugin_path
+          FileUtils.rm_rf(plugin_path)
+          Vimmer.remove_plugin(plugin_name)
+          puts "#{plugin_name} has been uninstalled"
+        else
+          raise Vimmer::PluginNotFoundError
+        end
+      end
+
+      def path_exists?
+        `curl --head -w %{http_code} -o /dev/null #{remove_extension(path)} 2> /dev/null`.chomp == "200"
+      end
+
+      private
+
+      def git_clone(path, install_to)
+        output = `git clone #{path} #{install_to}`
+      end
+
+      def remove_extension(path)
+        path.gsub(/\.git$/, '')
+      end      
+
+     def initialize_with_name(name)
+        @path = Vimmer.plugins[name]
+        @plugin_name = name
+      end      
+    end
+  end
+end

--- a/lib/vimmer/installers/git_url.rb
+++ b/lib/vimmer/installers/git_url.rb
@@ -3,42 +3,8 @@ module Vimmer
 
     GIT_URL_PATTERN = %r{^git://(\w|[-_+./])+/((\w|[-_+.])+)\.git$}
   
-    class GitUrl
-      attr_reader :path, :plugin_name
-
-      def initialize(args={})
-        if args[:path]
-          initialize_with_path(args[:path])
-        elsif args[:name]
-          initialize_with_name(args[:name])
-        end
-      end 
-
-      def install
-        if path_exists?
-          git_clone(path, File.join(Vimmer.bundle_path, plugin_name))
-          Vimmer.add_plugin(plugin_name, path)
-          puts "#{plugin_name} has been installed"
-        else
-          raise Vimmer::PluginNotFoundError
-        end
-      end     
-
-      def uninstall
-        plugin_path = File.join(Vimmer.bundle_path, plugin_name)
-        if File.directory? plugin_path
-          FileUtils.rm_rf(plugin_path)
-          Vimmer.remove_plugin(plugin_name)
-          puts "#{plugin_name} has been uninstalled"
-        else
-          raise Vimmer::PluginNotFoundError
-        end
-      end      
-
-      def path_exists?
-        `curl --head -w %{http_code} -o /dev/null #{remove_extension(path)} 2> /dev/null`.chomp == "200"
-      end
-
+    class GitUrl < BaseInstaller
+      
       def self.match?(url)
         is_git_url?(url)
       end
@@ -49,25 +15,11 @@ module Vimmer
 
       private
 
-      def git_clone(path, install_to)
-        output = `git clone #{path} #{install_to}`
-      end
-
       def initialize_with_path(path)
-
         raise Vimmer::InvalidPathError.new(path) unless path =~ GIT_URL_PATTERN
 
         @plugin_name = $2
         @path = path
-      end
-
-      def initialize_with_name(name)
-        @path = Vimmer.plugins[name]
-        @plugin_name = name
-      end
-
-      def remove_extension(path)
-        path.gsub(/\.git$/, '')
       end
 
     end

--- a/lib/vimmer/installers/git_url.rb
+++ b/lib/vimmer/installers/git_url.rb
@@ -1,0 +1,75 @@
+module Vimmer
+  module Installers
+
+    GIT_URL_PATTERN = %r{^git://(\w|[-_+./])+/((\w|[-_+.])+)\.git$}
+  
+    class GitUrl
+      attr_reader :path, :plugin_name
+
+      def initialize(args={})
+        if args[:path]
+          initialize_with_path(args[:path])
+        elsif args[:name]
+          initialize_with_name(args[:name])
+        end
+      end 
+
+      def install
+        if path_exists?
+          git_clone(path, File.join(Vimmer.bundle_path, plugin_name))
+          Vimmer.add_plugin(plugin_name, path)
+          puts "#{plugin_name} has been installed"
+        else
+          raise Vimmer::PluginNotFoundError
+        end
+      end     
+
+      def uninstall
+        plugin_path = File.join(Vimmer.bundle_path, plugin_name)
+        if File.directory? plugin_path
+          FileUtils.rm_rf(plugin_path)
+          Vimmer.remove_plugin(plugin_name)
+          puts "#{plugin_name} has been uninstalled"
+        else
+          raise Vimmer::PluginNotFoundError
+        end
+      end      
+
+      def path_exists?
+        `curl --head -w %{http_code} -o /dev/null #{remove_extension(path)} 2> /dev/null`.chomp == "200"
+      end
+
+      def self.match?(url)
+        is_git_url?(url)
+      end
+
+      def self.is_git_url?(url)
+        GIT_URL_PATTERN.match(url)
+      end
+
+      private
+
+      def git_clone(path, install_to)
+        output = `git clone #{path} #{install_to}`
+      end
+
+      def initialize_with_path(path)
+
+        raise Vimmer::InvalidPathError.new(path) unless path =~ GIT_URL_PATTERN
+
+        @plugin_name = $2
+        @path = path
+      end
+
+      def initialize_with_name(name)
+        @path = Vimmer.plugins[name]
+        @plugin_name = name
+      end
+
+      def remove_extension(path)
+        path.gsub(/\.git$/, '')
+      end
+
+    end
+  end
+end

--- a/lib/vimmer/installers/github.rb
+++ b/lib/vimmer/installers/github.rb
@@ -5,45 +5,7 @@ module Vimmer
     GITHUB_GIT_URL_PATTERN = %r{^https://github.com/[a-zA-Z0-9\-_\+%]+/([a-zA-Z0-9\-_\+\.]+).git$}
     GITHUB_PUBLIC_URL_PATTERN = %r{^https?://github.com/([a-zA-Z0-9\-_\+%]+)/([a-zA-Z0-9\-_\+\.]+[^.git])$}
 
-    class Github
-      attr_reader :path, :plugin_name
-
-      def initialize(args={})
-        if args[:path]
-          initialize_with_path(args[:path])
-        elsif args[:name]
-          initialize_with_name(args[:name])
-        end
-      end
-
-
-      def install
-        if path_exists?
-          git_clone(path, File.join(Vimmer.bundle_path, plugin_name))
-          Vimmer.add_plugin(plugin_name, path)
-          puts "#{plugin_name} has been installed"
-        else
-          raise Vimmer::PluginNotFoundError
-        end
-      end
-
-
-      def uninstall
-        plugin_path = File.join(Vimmer.bundle_path, plugin_name)
-        if File.directory? plugin_path
-          FileUtils.rm_rf(plugin_path)
-          Vimmer.remove_plugin(plugin_name)
-          puts "#{plugin_name} has been uninstalled"
-        else
-          raise Vimmer::PluginNotFoundError
-        end
-      end
-
-
-      def path_exists?
-        `curl --head -w %{http_code} -o /dev/null #{remove_extension(path)} 2> /dev/null`.chomp == "200"
-      end
-
+    class Github < BaseInstaller
 
       def self.match?(url)
         is_github_url?(url)
@@ -54,13 +16,7 @@ module Vimmer
           GITHUB_GIT_URL_PATTERN.match(url)).nil?
       end
 
-
       private
-
-      def git_clone(path, install_to)
-        output = `git clone #{path} #{install_to}`
-      end
-
 
       def initialize_with_path(path)
 
@@ -71,18 +27,6 @@ module Vimmer
         @plugin_name = $1
         @path = path
       end
-
-
-      def initialize_with_name(name)
-        @path = Vimmer.plugins[name]
-        @plugin_name = name
-      end
-
-
-      def remove_extension(path)
-        path.gsub(/\.git$/, '')
-      end
-
 
       def public_path_to_git_path(user, repo)
         GITHUB_GIT_PATH_TEMPLATE % [user, repo]

--- a/spec/install/git_url_spec.rb
+++ b/spec/install/git_url_spec.rb
@@ -1,0 +1,133 @@
+require 'spec_helper'
+
+include Vimmer::Installers
+
+describe "When installing from git:// urls" do
+
+  GIT_FOUND_URL = "git://git.wincent.com/command-t.git"
+  GIT_NOT_FOUND_URL = "git://git.wincent.com/command-not-found.git"
+  GIT_MALFORMED_URL = "git://foo.com/bar"
+
+  RSpec::Matchers.define :be_a_valid_git_url do |expected|
+    match do
+      GitUrl.match?(expected)
+    end
+  end
+
+  context "with a non-existant URL" do
+
+    let(:installer) { GitUrl.new(:path => GIT_NOT_FOUND_URL) }
+
+    before(:each) do
+      installer.stubs(:path_exists?).returns(false)
+      installer.stubs(:git_clone)
+    end
+
+    it { should be_a_valid_git_url(GIT_NOT_FOUND_URL) }
+
+    specify "the installer should raise an exception" do
+      lambda { installer.install }.should raise_error(Vimmer::PluginNotFoundError)
+    end
+  end
+
+  context "with a good URL" do
+
+    let(:installer) { GitUrl.new(:path => GIT_FOUND_URL) }
+
+    before do
+      installer.stubs(:git_clone)
+      installer.stubs(:path_exists?).returns(true)
+    end
+
+    it { should be_a_valid_github_url(FOUND_URL) }
+
+    specify "the installer should not raise an exception" do
+      lambda { installer.install }.should_not raise_error
+    end
+
+    specify "the installer calculates the plugin's name" do
+      installer.plugin_name.should == "command-t"
+    end
+
+  end  
+
+  context "with a malformed URL" do
+
+    let(:installer) { GitUrl.new(:path => GIT_MALFORMED_URL) }
+
+
+    it { should_not be_a_valid_github_url(GIT_MALFORMED_URL) }
+
+    specify "the installer should raise an exception" do
+      lambda { installer }.should raise_error(Vimmer::InvalidPathError)
+    end
+
+  end  
+
+  it "provides access to the path" do
+    GitUrl.new(:path => GIT_FOUND_URL).
+      path.should == GIT_FOUND_URL
+  end  
+
+  it "adds plugin to list of installed plugins" do
+
+    installer = GitUrl.new(:path => GIT_FOUND_URL)
+
+    installer.stubs(:path_exists?).returns(true)
+    installer.stubs(:git_clone)
+
+    installer.install
+
+    Vimmer.plugins["command-t"].should == GIT_FOUND_URL
+  end
+
+  it "installs the plugin" do
+
+    installer = GitUrl.new(:path => GIT_FOUND_URL)
+
+    stub_for_install! installer
+
+    installer.install
+
+    plugin_path = Vimmer.bundle_path.join("command-t")
+
+
+    File.directory?(plugin_path.to_s).should be_true
+    File.directory?(plugin_path.join("plugins").to_s).should be_true
+    File.file?(plugin_path.join("plugins", "command-t.vim")).should be_true
+
+  end
+ 
+  it "uninstalls the plugin" do
+
+    installer = GitUrl.new(:name => "command-t")
+
+
+    stub_for_install! installer
+
+    installer.install
+
+    installer.uninstall
+
+    plugin_path = Vimmer.bundle_path.join("command-t")
+    File.directory?(plugin_path.to_s).should be_false
+    File.directory?(plugin_path.join("plugins").to_s).should be_false
+  end
+
+  private
+
+  def stub_for_install!(installer)
+
+    Vimmer.stubs(:bundle_path).returns(Pathname.new("tmp/bundle"))
+
+    class << installer
+      def git_clone(arg1, arg2)
+        FileUtils.mkdir_p(Vimmer.bundle_path.join("command-t", "plugins"))
+        FileUtils.touch(Vimmer.bundle_path.join("command-t", "plugins", "command-t.vim"))
+      end
+    end
+
+    installer.stubs(:path_exists?).returns true
+
+  end
+end

--- a/spec/install/load_installer_spec.rb
+++ b/spec/install/load_installer_spec.rb
@@ -11,6 +11,13 @@ describe "When loading an installer by URL" do
 
   end
 
+  context "for a git:// URL" do
+
+    subject { Installers.for_url("git://git.wincent.com/command-t.git") }
+
+    it { should == Installers::GitUrl }
+
+  end  
 
   context "for a Vim.org URL" do
 
@@ -23,7 +30,6 @@ describe "When loading an installer by URL" do
     it { should == Installers::VimDotOrg }
 
   end
-
 
   context "for an unrecognized URL" do
 


### PR DESCRIPTION
The first commit is a fix so that lib folder get discovered properly when running Cucumber. I've created a separate issue for that one. The 3 commits after that add the capability to install bundles from non github git:// repos. 

I'll be the first to admit that its not necessarily a particularly useful feature, but my first attempt at installing Command-T failed because it was using a non github git account; I ran into a "bad url" error and decided I might as well try and do something about it. I've since realized that there is a github mirror for Command-T, but oh well...
